### PR TITLE
Changes to LHEEvetProductAnalyzer to prevent segfaults when a sample …

### DIFF
--- a/src/LHEEventProductAnalyzer.cc
+++ b/src/LHEEventProductAnalyzer.cc
@@ -14,19 +14,19 @@ verbosity_(0), lheEventProductProducer_(producersNames.getParameter<edm::InputTa
 }
 
 LHEEventProductAnalyzer::LHEEventProductAnalyzer(const edm::ParameterSet& producersNames, int verbosity):
-verbosity_(verbosity), 
+verbosity_(verbosity),
 lheEventProductProducer_(producersNames.getParameter <edm::InputTag>("lheEventProductProducer"))
 {
 }
 
 LHEEventProductAnalyzer::LHEEventProductAnalyzer(const edm::ParameterSet& producersNames, const edm::ParameterSet& myConfig, int verbosity):
-verbosity_(verbosity), 
+verbosity_(verbosity),
 lheEventProductProducer_(producersNames.getParameter <edm::InputTag>("lheEventProductProducer"))
 {
 }
 
 LHEEventProductAnalyzer::LHEEventProductAnalyzer(const edm::ParameterSet& producersNames, int iter, const edm::ParameterSet& myConfig, int verbosity):
-verbosity_(verbosity), 
+verbosity_(verbosity),
 lheEventProductProducer_(edm::InputTag(vLHEEventProductProducer[iter])),
 vLHEEventProductProducer(producersNames.getUntrackedParameter <std::vector<std::string> >("vlheEventProductProducer"))
 {
@@ -52,29 +52,39 @@ void LHEEventProductAnalyzer::Process(const edm::Event& iEvent, TRootEvent* root
 		if(verbosity_ > 1) cout << "Analysing LHEEventProduct, collection present "<<endl;
 
 		const std::vector<WGT>& weights  = lheEventProduct->weights();
-
+        if(verbosity_ > 1) cout << "Analysing LHEEventProduct, weights vector assigned"<<endl;
 		std::vector<Float_t> weights_d;
 
-		for (int w = 0; w < 9; w++)
+		for (unsigned int w = 0; w < 9; w++)
 		{
+		    if(weights.size() > w)
+            {
 			std::string weight_id = weights[w].id;
+			if(verbosity_ > 1) cout << "Analysing LHEEventProduct, Weight name extracted"<<endl;
 			double weight_val = weights[w].wgt;
+			if(verbosity_ > 1) cout << "Analysing LHEEventProduct, Weight value extracted"<<endl;
 			weights_d.push_back(weight_val);
 
 			if(verbosity_ > 1) cout <<"id  "<< weight_id  <<"  weight = " << weight_val << endl;
-
+		    }
 		}
-
+        if(weights_d.size() == 9)
+        {
 		rootEvent->setWeights(weights_d);
 
 		if(verbosity_ > 1) cout << "Weights succesfully extracted  "<<   endl;
+        }
+        else
+        {
+            if(verbosity_ > 0) cout <<"Incorrect number of weights (" << weights_d.size() << ") in LHEEventProduct collection" << endl;
+        }
 
-	} 
+	}
 }
 
 // void LHEEventProductAnalyzer::PrintWeightNamesList(const edm::Event& iEvent, TRootEvent* rootEvent) //To know which integer XXX corresponds to which weight
 // {
-// 	edm::Handle<LHERunInfoProduct> run; 
+// 	edm::Handle<LHERunInfoProduct> run;
 // 	typedef std::vector<LHERunInfoProduct::Header>::const_iterator headers_const_iterator;
 
 // 	iRun.getByLabel( "externalLHEProducer", run );


### PR DESCRIPTION
…has a LHEEventProduct collection but it is empty.  Samples like this will output a status message to their log file whenever there is the wrong number of weights in the LHEEventProduct collection (9 is the correct amount for the moment).  When the details of how weights will be handled are decided, this code should be updated in conform with the new paradigm.