### PR TITLE
TTP MVA electron ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __init__.py
 *.so
 prod/expanded.py
 prod/nohup.out
+prod/*.root
+src/Dict_rdict.pcm

--- a/interface/ElectronAnalyzer.h
+++ b/interface/ElectronAnalyzer.h
@@ -36,7 +36,7 @@ class ElectronAnalyzer{
 public:
 	ElectronAnalyzer(const edm::ParameterSet& myConfig, int verbosity);
 	~ElectronAnalyzer();
-	void Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<pat::ElectronCollection> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken);
+	void Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken);
   typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsoDepositVals;
 
 private:

--- a/interface/ElectronAnalyzer.h
+++ b/interface/ElectronAnalyzer.h
@@ -36,7 +36,9 @@ class ElectronAnalyzer{
 public:
 	ElectronAnalyzer(const edm::ParameterSet& myConfig, int verbosity);
 	~ElectronAnalyzer();
-	void Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken);
+	// From CMSSW_8_1_X onwards
+	//void Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken);
+	void Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken);
   typedef std::vector< edm::Handle< edm::ValueMap<double> > > IsoDepositVals;
 
 private:

--- a/interface/TRootElectron.h
+++ b/interface/TRootElectron.h
@@ -55,8 +55,6 @@ class TRootElectron : public TRootLepton {
             r9_(9999.),
             fBrem_(-9999.),
             nBrems_(-9999),
-            Dist_(9999.),
-            DCot_(9999.),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -103,8 +101,6 @@ class TRootElectron : public TRootLepton {
             r9_(9999.),
             fBrem_(-9999.),
             nBrems_(-9999),
-            Dist_(9999.),
-            DCot_(9999.),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -151,8 +147,6 @@ class TRootElectron : public TRootLepton {
             r9_(e.r9_),
             fBrem_(e.fBrem_),
             nBrems_(e.nBrems_),
-            Dist_(e.Dist_),
-            DCot_(e.DCot_),
             passConversion_(e.passConversion_),
             mvaTrigId_(e.mvaTrigId_),
             mvaNonTrigId_(e.mvaNonTrigId_) {
@@ -200,8 +194,6 @@ class TRootElectron : public TRootLepton {
             r9_(-9999.),
             fBrem_(-9999.),
             nBrems_(-9999),
-            Dist_(9999),
-            DCot_(9999),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -249,8 +241,6 @@ class TRootElectron : public TRootLepton {
             r9_(-9999.),
             fBrem_(-9999.),
             nBrems_(-9999),
-            Dist_(9999),
-            DCot_(9999),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -298,8 +288,6 @@ class TRootElectron : public TRootLepton {
             r9_(-9999.),
             fBrem_(-9999.),
             nBrems_(-9999),
-            Dist_(9999),
-            DCot_(9999),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -347,8 +335,6 @@ class TRootElectron : public TRootLepton {
             r9_(-9999.),
             fBrem_(-9999.),
             nBrems_(9999),
-            Dist_(9999),
-            DCot_(9999),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -396,8 +382,6 @@ class TRootElectron : public TRootLepton {
             r9_(-9999.),
             fBrem_(-9999.),
             nBrems_(9999),
-            Dist_(9999),
-            DCot_(9999),
             passConversion_(false),
             mvaTrigId_(-9999.),
             mvaNonTrigId_(-9999.) {
@@ -541,12 +525,6 @@ class TRootElectron : public TRootLepton {
         Int_t numberOfBrems() const {
             return nBrems_;
             }
-        Float_t Dist() const {
-            return Dist_;
-            }
-        Float_t DCot() const {
-            return DCot_;
-            }
         Bool_t passConversion() const {
             return passConversion_;
             }
@@ -679,12 +657,6 @@ class TRootElectron : public TRootLepton {
         void setNBrems(Int_t n) {
             nBrems_ = n;
             }
-        void setDist(Float_t dist) {
-            Dist_ = dist;
-            }
-        void setDCot(Float_t dcot) {
-            DCot_ = dcot;
-            }
         void setPassConversion(Bool_t pass) {
             passConversion_ = pass;
             }
@@ -754,8 +726,6 @@ class TRootElectron : public TRootLepton {
         // Electron classification && fBrem ====================
         Float_t fBrem_;                            // brem fraction from gsf fit: (track momentum in - track momentum out) / track momentum in
         Int_t   nBrems_;                           // number of basic clusters inside the supercluster - 1
-        Float_t Dist_;                             // distance to the conversion partner
-        Float_t DCot_;                             // difference of cot(angle) with the conversion partner track
         Bool_t  passConversion_;                   // boolean to flag converted candidates
         
 	Float_t mvaTrigId_;                        // MVA value

--- a/interface/TRootElectron.h
+++ b/interface/TRootElectron.h
@@ -56,8 +56,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(-9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
         TRootElectron(const TRootLepton& l) :
@@ -102,8 +105,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(-9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
         TRootElectron(const TRootElectron& e) :
@@ -148,8 +154,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(e.fBrem_),
             nBrems_(e.nBrems_),
             passConversion_(e.passConversion_),
-            mvaTrigId_(e.mvaTrigId_),
-            mvaNonTrigId_(e.mvaNonTrigId_) {
+            isMVA_TightID_(e.isMVA_TightID_),
+            isMVA_MediumID_(e.isMVA_MediumID_),
+            isMVA_LooseID_(e.isMVA_LooseID_),
+            MVA_value_(e.MVA_value_),
+            MVA_category_(e.MVA_category_){
             ;
             }
 
@@ -195,8 +204,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(-9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
 
@@ -242,8 +254,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(-9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
 
@@ -289,8 +304,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(-9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
 
@@ -336,8 +354,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
 
@@ -383,8 +404,11 @@ class TRootElectron : public TRootLepton {
             fBrem_(-9999.),
             nBrems_(9999),
             passConversion_(false),
-            mvaTrigId_(-9999.),
-            mvaNonTrigId_(-9999.) {
+            isMVA_TightID_(false),
+            isMVA_MediumID_(false),
+            isMVA_LooseID_(false),
+            MVA_value_(-9999.),
+            MVA_category_(-9999){
             ;
             }
 
@@ -528,11 +552,20 @@ class TRootElectron : public TRootLepton {
         Bool_t passConversion() const {
             return passConversion_;
             }
-        Float_t mvaTrigId() const {
-            return mvaTrigId_;
+        Bool_t isMVA_TightID() const {
+            return isMVA_TightID_;
             }
-        Float_t mvaNonTrigId() const {
-            return mvaNonTrigId_;
+        Bool_t isMVA_MediumID() const {
+            return isMVA_MediumID_;
+            }
+        Bool_t isMVA_LooseID() const {
+            return isMVA_LooseID_;
+            }
+        Float_t MVA_value() const {
+            return MVA_value_;
+            }
+        Int_t MVA_category() const {
+            return MVA_category_;
             }
 
         //setters
@@ -660,11 +693,20 @@ class TRootElectron : public TRootLepton {
         void setPassConversion(Bool_t pass) {
             passConversion_ = pass;
             }
-        void setMvaTrigId(Float_t id) {
-            mvaTrigId_ = id;
+        void setisMVA_TightID(Bool_t pass) {
+            isMVA_TightID_ = pass;
             }
-        void setMvaNonTrigId(Float_t id) {
-            mvaNonTrigId_ = id;
+        void setisMVA_MediumID(Bool_t pass) {
+            isMVA_MediumID_ = pass;
+            }
+        void setisMVA_LooseID(Bool_t pass) {
+            isMVA_LooseID_ = pass;
+            }
+        void setMVA_value(Float_t value) {
+            MVA_value_ = value;
+            }
+        void setMVA_category(Int_t category) {
+            MVA_category_ = category;
             }
         friend std::ostream& operator<< (std::ostream& stream, const TRootElectron& electron) {
             stream << "TRootElectron - Charge=" << electron.charge() << " (Et,eta,phi)=("<< electron.Et() <<","<< electron.Eta() <<","<< electron.Phi() << ")"
@@ -728,8 +770,11 @@ class TRootElectron : public TRootLepton {
         Int_t   nBrems_;                           // number of basic clusters inside the supercluster - 1
         Bool_t  passConversion_;                   // boolean to flag converted candidates
         
-	Float_t mvaTrigId_;                        // MVA value
-        Float_t mvaNonTrigId_;                     // MVA value
+	      Bool_t isMVA_TightID_; // Tight ID from MVA electrons. Newly implemented in 2016, according to https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+        Bool_t isMVA_MediumID_;// Medium ID from MVA electrons. Newly implemented in 2016, according to https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+        Bool_t isMVA_LooseID_;// Loose ID from MVA electrons. Newly implemented in 2016, according to https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+        Float_t MVA_value_; // MVA value of MVA electrons. Newly implemented in 2016, according to https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+        Float_t MVA_category_; // Catefory of MVA electrons. Newly implemented in 2016, according to https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
 
 
         ClassDef (TRootElectron,14);

--- a/interface/TRootLepton.h
+++ b/interface/TRootLepton.h
@@ -19,7 +19,6 @@ namespace TopTree
 		TRootLepton() :
 		TRootParticle(),
 		ip3d_(-9999.),
-		ip3dErr_(-9999.),
 		d0_(-9999.),
 		d0Error_(-9999.),
 		d0BeamSpot_(-9999.),
@@ -49,7 +48,6 @@ namespace TopTree
 		TRootLepton(const TRootLepton& lepton) :
 		TRootParticle(lepton),
 		ip3d_(lepton.ip3d_),
-		ip3dErr_(lepton.ip3dErr_),
 		d0_(lepton.d0_),
 		d0Error_(lepton.d0Error_),
 		d0BeamSpot_(lepton.d0BeamSpot_),
@@ -79,7 +77,6 @@ namespace TopTree
 		TRootLepton(Double_t px, Double_t py, Double_t pz, Double_t e) :
 		TRootParticle(px,py,pz,e),
 		ip3d_(-9999.),
-		ip3dErr_(-9999.),
 		d0_(-9999.),
 		d0Error_(-9999.),
 		d0BeamSpot_(-9999.),
@@ -109,7 +106,6 @@ namespace TopTree
 		TRootLepton(Double_t px, Double_t py, Double_t pz, Double_t e, Double_t vtx_x, Double_t vtx_y, Double_t vtx_z) :
 		TRootParticle(px,py,pz,e,vtx_x,vtx_y,vtx_z),
 		ip3d_(-9999.),
-		ip3dErr_(-9999.),
 		d0_(-9999.),
 		d0Error_(-9999.),
 		d0BeamSpot_(-9999.),
@@ -139,7 +135,6 @@ namespace TopTree
 		TRootLepton(Double_t px, Double_t py, Double_t pz, Double_t e, Double_t vtx_x, Double_t vtx_y, Double_t vtx_z, Int_t type, Int_t charge) :
 		TRootParticle(px,py,pz,e,vtx_x,vtx_y,vtx_z,type,charge),
 		ip3d_(-9999.),
-		ip3dErr_(-9999.),
 		d0_(-9999.),
 		d0Error_(-9999.),
 		d0BeamSpot_(-9999.),
@@ -169,7 +164,6 @@ namespace TopTree
 		TRootLepton(const TLorentzVector &momentum) :
 		TRootParticle(momentum),
 		ip3d_(-9999.),
-		ip3dErr_(-9999.),
 		d0_(-9999.),
 		d0Error_(-9999.),
 		d0BeamSpot_(-9999.),
@@ -199,7 +193,6 @@ namespace TopTree
 		TRootLepton(const TLorentzVector &momentum, const TVector3 &vertex, Int_t type, Float_t charge) :
 		TRootParticle(momentum,vertex,type,charge),
 		ip3d_(-9999.),
-		ip3dErr_(-9999.),
 		d0_(-9999.),
 		d0Error_(-9999.),
 		d0BeamSpot_(-9999.),
@@ -233,7 +226,6 @@ namespace TopTree
 		virtual TString typeName() const { return "TRootLepton"; }
 		
 		Float_t ip3d() const { return ip3d_; }
-		Float_t ip3dError() const { return ip3dErr_; }
 		Float_t d0() const { return d0_; }
 		Float_t d0Error()const { return d0Error_; }
 		Float_t d0BeamSpot() const { return d0BeamSpot_; }
@@ -331,7 +323,6 @@ namespace TopTree
 		
 		//setters
 		void setIp3d(Float_t x) { ip3d_ = x; }
-		void setIp3dError(Float_t x) { ip3dErr_ = x; }
 		void setD0(Float_t x) { d0_ = x; }
 		void setD0Error(Float_t x) { d0Error_ = x; }
 		void setD0BeamSpot(Float_t x) { d0BeamSpot_ = x; }
@@ -365,7 +356,6 @@ namespace TopTree
 		
 		//TrackProperties=====================================
 		Float_t ip3d_;                             // 3D impact parameter
-		Float_t ip3dErr_;                          // error on ip3d_
 		Float_t d0_;                         	     // transverse impact parameter (wrt to PV)
 		Float_t d0Error_;                          // error on d0_
 		Float_t d0BeamSpot_;                         	     // transverse impact parameter (wrt to beam spot)

--- a/interface/TRootLepton.h
+++ b/interface/TRootLepton.h
@@ -27,14 +27,6 @@ namespace TopTree
 		dzError_(-9999.),
 		dzBeamSpot_(-9999.),
 		dzBeamSpotError_(-9999.),
-		//    dB_(-9999.),
-		//    dBError_(-9999.),
-		trackIso03_(-9999.),
-		ecalIso03_(-9999.),
-		hcalIso03_(-9999.),
-		trackIso04_(-9999.),
-		ecalIso04_(-9999.),
-		hcalIso04_(-9999.),
 		chargedHadronIso03_(-9999),
 		puChargedHadronIso03_(-9999.),
 		photonIso03_(-9999),
@@ -56,14 +48,6 @@ namespace TopTree
 		dzError_(lepton.dzError_),
 		dzBeamSpot_(lepton.dzBeamSpot_),
 		dzBeamSpotError_(lepton.dzBeamSpotError_),
-		//    dB_(lepton.dB_),
-		//    dBError_(lepton.dBError_),
-		trackIso03_(lepton.trackIso03_),
-		ecalIso03_(lepton.ecalIso03_),
-		hcalIso03_(lepton.hcalIso03_),
-		trackIso04_(lepton.trackIso04_),
-		ecalIso04_(lepton.ecalIso04_),
-		hcalIso04_(lepton.hcalIso04_),
 		chargedHadronIso03_(lepton.chargedHadronIso03_),
 		puChargedHadronIso03_(lepton.puChargedHadronIso03_),
 		photonIso03_(lepton.photonIso03_),
@@ -85,14 +69,6 @@ namespace TopTree
 		dzError_(-9999.),
 		dzBeamSpot_(-9999.),
 		dzBeamSpotError_(-9999.),
-		//    dB_(-9999.),
-		//    dBError_(-9999.),
-		trackIso03_(-9999.),
-		ecalIso03_(-9999.),
-		hcalIso03_(-9999.),
-		trackIso04_(-9999.),
-		ecalIso04_(-9999.),
-		hcalIso04_(-9999.),
 		chargedHadronIso03_(-9999),
 		puChargedHadronIso03_(-9999.),
 		photonIso03_(-9999),
@@ -114,14 +90,6 @@ namespace TopTree
 		dzError_(-9999.),
 		dzBeamSpot_(-9999.),
 		dzBeamSpotError_(-9999.),
-		//    dB_(-9999.),
-		//    dBError_(-9999.),
-		trackIso03_(-9999.),
-		ecalIso03_(-9999.),
-		hcalIso03_(-9999.),
-		trackIso04_(-9999.),
-		ecalIso04_(-9999.),
-		hcalIso04_(-9999.),
 		chargedHadronIso03_(-9999),
 		puChargedHadronIso03_(-9999.),
 		photonIso03_(-9999),
@@ -143,14 +111,6 @@ namespace TopTree
 		dzError_(-9999.),
 		dzBeamSpot_(-9999.),
 		dzBeamSpotError_(-9999.),
-		//    dB_(-9999.),
-		//    dBError_(-9999.),
-		trackIso03_(-9999.),
-		ecalIso03_(-9999.),
-		hcalIso03_(-9999.),
-		trackIso04_(-9999.),
-		ecalIso04_(-9999.),
-		hcalIso04_(-9999.),
 		chargedHadronIso03_(-9999),
 		puChargedHadronIso03_(-9999.),
 		photonIso03_(-9999),
@@ -172,14 +132,6 @@ namespace TopTree
 		dzError_(-9999.),
 		dzBeamSpot_(-9999.),
 		dzBeamSpotError_(-9999.),
-		//    dB_(-9999.),
-		//    dBError_(-9999.),
-		trackIso03_(-9999.),
-		ecalIso03_(-9999.),
-		hcalIso03_(-9999.),
-		trackIso04_(-9999.),
-		ecalIso04_(-9999.),
-		hcalIso04_(-9999.),
 		chargedHadronIso03_(-9999),
 		puChargedHadronIso03_(-9999.),
 		photonIso03_(-9999),
@@ -201,14 +153,6 @@ namespace TopTree
 		dzError_(-9999.),
 		dzBeamSpot_(-9999.),
 		dzBeamSpotError_(-9999.),
-		//    dB_(-9999.),
-		//    dBError_(-9999.),
-		trackIso03_(-9999.),
-		ecalIso03_(-9999.),
-		hcalIso03_(-9999.),
-		trackIso04_(-9999.),
-		ecalIso04_(-9999.),
-		hcalIso04_(-9999.),
 		chargedHadronIso03_(-9999),
 		puChargedHadronIso03_(-9999.),
 		photonIso03_(-9999),
@@ -234,44 +178,6 @@ namespace TopTree
 		Float_t dzError()const { return dzError_; }
 		Float_t dzBeamSpot() const { return dzBeamSpot_; }
 		Float_t dzBeamSpotError()const { return dzBeamSpotError_; }
-		//		Float_t dB() const { return dB_; }
-		//		Float_t dBError() const { return dBError_; }
-		
-		//detector based isolation
-		Float_t ecalIso(unsigned int cone) const
-		{
-			if(cone == 3) return ecalIso03_;
-			else if(cone == 4) return ecalIso04_;
-			else cout<<"Bad Cone Size! It returns 9999."<<endl;
-			return 9999.;
-		}
-		Float_t hcalIso(unsigned int cone) const
-		{
-			if(cone == 3) return hcalIso03_;
-			else if(cone == 4) return hcalIso04_;
-			else cout<<"Bad Cone Size! It returns 9999."<<endl;
-			return 9999.;
-		}
-		Float_t caloIso(unsigned int cone) const
-		{
-			return (ecalIso(cone) + hcalIso(cone));
-		}
-		Float_t trackIso(unsigned int cone) const
-		{
-			if(cone == 3) return trackIso03_;
-			else if(cone == 4) return trackIso04_;
-			else cout<<"Bad Cone Size! It returns 9999."<<endl;
-			return 9999.;
-		}
-		Float_t absDetIso(unsigned int cone) const
-		{
-			return (trackIso(cone) + hcalIso(cone) + ecalIso(cone));
-		}
-		Float_t relDetIso(unsigned int cone) const
-		{
-			double relIso = absDetIso(cone)/((TLorentzVector)(*this)).Pt();
-			return relIso;
-		}
 	
 		//particle based isolation
 		Float_t chargedHadronIso(unsigned int cone) const
@@ -331,16 +237,6 @@ namespace TopTree
 		void setDzError(Float_t x) { dzError_ = x; }
 		void setDzBeamSpot(Float_t x) { dzBeamSpot_ = x; }
 		void setDzBeamSpotError(Float_t x) { dzBeamSpotError_ = x; }
-		//void setDB(Float_t dB) { dB_ = dB; }
-		//void setDBError(Float_t dBError) { dBError_ = dBError; }
-		
-		//detector based isolation
-		void setIsoR03_trackIso(Float_t isoR03_trackIso) { trackIso03_ = isoR03_trackIso; }
-		void setIsoR03_ecalIso(Float_t isoR03_ecalIso)   { ecalIso03_ = isoR03_ecalIso; }
-		void setIsoR03_hcalIso(Float_t isoR03_hcalIso)   { hcalIso03_ = isoR03_hcalIso; }
-		void setIsoR04_trackIso(Float_t isoR04_trackIso) { trackIso04_ = isoR04_trackIso; }
-		void setIsoR04_ecalIso(Float_t isoR04_ecalIso)   { ecalIso04_ = isoR04_ecalIso; }
-		void setIsoR04_hcalIso(Float_t isoR04_hcalIso)   { hcalIso04_ = isoR04_hcalIso; }
 		
 		//particle based isolation
 		void setIsoR03_ChargedHadronIso(Float_t chargedHadronIso){ chargedHadronIso03_ = chargedHadronIso; }
@@ -364,19 +260,6 @@ namespace TopTree
 		Float_t dzError_;                          // error on dz_
 		Float_t dzBeamSpot_;                         	     // longitudinal impact parameter (wrt to beam spot)
 		Float_t dzBeamSpotError_;                          // error on dzBeamSpot_
-		
-		// If this was not the case, dB is calculated wrt the beamspot and edb = -1 all the time
-		//Float_t dB_;                             // dB from PAT muon
-		//Float_t dBError_;                        // dBError from PAT muon
-		
-		//Isolation ============================================
-		//detector based isolation
-		Float_t trackIso03_;                        // track iso deposit with electron footprint removed
-		Float_t ecalIso03_;                // ecal iso deposit with electron footprint removed
-		Float_t hcalIso03_;           // hcal depht 1 iso deposit with electron footprint removed
-		Float_t trackIso04_;                        // track iso deposit with electron footprint removed
-		Float_t ecalIso04_;                // ecal iso deposit with electron footprint removed
-		Float_t hcalIso04_;           // hcal depht 1 iso deposit with electron footprint removed
 		
 		//particle based isolation
 		Float_t chargedHadronIso03_;                 // isolation calculated with only the charged hadron candidates

--- a/interface/TopTreeProducer.h
+++ b/interface/TopTreeProducer.h
@@ -153,7 +153,7 @@ private:
     // good practice is to use these instead of getbylabel. However getbylabel is still supported...
     edm::EDGetTokenT<reco::VertexCollection> vtxToken_;
     std::vector<edm::EDGetTokenT<pat::MuonCollection> > vmuonToken_;
-    std::vector<edm::EDGetTokenT<pat::ElectronCollection> > velectronToken_;
+    std::vector<edm::EDGetTokenT<edm::View<pat::Electron>> > velectronToken_;
     std::vector<edm::EDGetTokenT<pat::PhotonCollection> > vphotonToken_;
     std::vector<edm::EDGetTokenT<pat::JetCollection> > vjetToken_;
     std::vector<edm::EDGetTokenT<pat::JetCollection> > vfatjetToken_;
@@ -178,6 +178,14 @@ private:
 	  edm::EDGetTokenT<LHERunInfoProduct> lheRunInfoproductToken_;
     
     edm::EDGetTokenT<reco::BeamSpot> offlineBSToken_;
+    // ID decisions objects
+    edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken_;
+    edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken_;
+    edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken_;
+
+    // MVA values and categories (optional)
+    edm::EDGetTokenT<edm::ValueMap<float> > mvaValuesMapToken_;
+    edm::EDGetTokenT<edm::ValueMap<int> > mvaCategoriesMapToken_;
 
 
     

--- a/interface/TopTreeProducer.h
+++ b/interface/TopTreeProducer.h
@@ -179,7 +179,7 @@ private:
     
     edm::EDGetTokenT<reco::BeamSpot> offlineBSToken_;
     // ID decisions objects
-    edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken_;
+    //edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken_;// From CMSSW_8_1_X onwards
     edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken_;
     edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken_;
 

--- a/prod/TOPTREE_fromminiAOD.py
+++ b/prod/TOPTREE_fromminiAOD.py
@@ -31,22 +31,6 @@ process.HBHENoiseFilterResultProducer.defaultDecision = cms.string("HBHENoiseFil
 #end of cmssw code for cleaning filters...
 
 
-## Setup VID for electrons (to have MVA value map)
-#process.load('RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff')
-#process.electronMVAValueMapProducer.srcMiniAOD = cms.InputTag('slimmedElectrons')
-#process.egmGsfElectronIDs.physicsObjectSrc = cms.InputTag('slimmedElectrons')
-#
-#elecID_mod_ls = [
-#  'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
-#  'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
-#  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_'+'nonTrig_V1_cff',
-#  'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_'+   'Trig_V1_cff',
-#]
-#
-#from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
-#for mod in elecID_mod_ls: setupAllVIDIdsInModule(process, mod, setupVIDElectronSelection)
-
-
 #
 # Set up electron ID (VID framework)
 #
@@ -55,7 +39,6 @@ from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 # turn on VID producer, indicate data format  to be
 # DataFormat.AOD or DataFormat.MiniAOD, as appropriate 
 dataFormat = DataFormat.MiniAOD
-#process.load('RecoEgamma.ElectronIdentification.egmGsfElectronIDs_cff')
 
 switchOnVIDElectronIdProducer(process, dataFormat)
 
@@ -220,7 +203,7 @@ process.analysis = cms.EDAnalyzer("TopTreeProducer",
 		hltProducer4th = cms.InputTag("TriggerResults","","PAT"),
 		electronMVAvaluesMapNonTrig = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"), #https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
 		electronMVACategoriesNonTrig = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Categories"),
-		eleLooseIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wpLoose"),
+		#eleLooseIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wpLoose"), #Will only be available from CMSSW_8_1_X
 		eleMediumIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp90"),
 		eleTightIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wp80")
 

--- a/src/ElectronAnalyzer.cc
+++ b/src/ElectronAnalyzer.cc
@@ -18,11 +18,11 @@ ElectronAnalyzer::~ElectronAnalyzer()
 {
 }
 
-void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<pat::ElectronCollection> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken)
+void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken)
 {
   unsigned int nElectrons=0;
 
-  edm::Handle < std::vector <pat::Electron> > patElectrons;
+  edm::Handle < edm::View<pat::Electron> > patElectrons;
   iEvent.getByToken(electronToken, patElectrons);
   nElectrons = patElectrons->size();
 
@@ -32,13 +32,31 @@ void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElect
   edm::Handle<reco::BeamSpot> beamSpotHandle;
   iEvent.getByToken(offlineBSToken, beamSpotHandle);
 
+  // Get the electron ID data from the event stream.
+  // Note: this implies that the VID ID modules have been run upstream.
+  // If you need more info, check with the EGM group.
+  edm::Handle<edm::ValueMap<bool> > loose_id_decisions;
+  edm::Handle<edm::ValueMap<bool> > medium_id_decisions;
+  edm::Handle<edm::ValueMap<bool> > tight_id_decisions; 
+  iEvent.getByToken(eleLooseIdMapToken,loose_id_decisions);
+  iEvent.getByToken(eleMediumIdMapToken,medium_id_decisions);
+  iEvent.getByToken(eleTightIdMapToken,tight_id_decisions);
+
+  // Get MVA values and categories (optional)
+  edm::Handle<edm::ValueMap<float> > mvaValues;
+  edm::Handle<edm::ValueMap<int> > mvaCategories;
+  iEvent.getByToken(EleMVAValuesMapToken,mvaValues);
+  iEvent.getByToken(EleMVACategoriesMapToken,mvaCategories);
+
   if(verbosity_>1) std::cout << "   Number of electrons = " << nElectrons << std::endl;
 
+  //std::vector <reco::GsfElectron> electrons = (std::vector <reco::GsfElectron>) patElectrons;
   for (unsigned int j=0; j<nElectrons; j++)
   {
     const pat::Electron*  patElectron = &((*patElectrons)[j]);//dynamic_cast<const pat::Electron*>(&*electron);
     const reco::GsfElectron* electron = (const reco::GsfElectron*) patElectron;//( & ((*patElectrons)[j]) );
-
+    const auto el = patElectrons->ptrAt(j);
+     
     TRootElectron localElectron(
                                 electron->px()
                                 ,electron->py()
@@ -192,9 +210,18 @@ void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElect
 	  std::cout << eleIds[ii].first << " " << eleIds[ii].second << std::endl;
       }
     }
-    localElectron.setMvaTrigId( patElectron->electronID("eidRobustLoose") );
-    localElectron.setMvaNonTrigId( patElectron->electronID("eidRobustTight") );
+    bool isPassLoose = (*loose_id_decisions)[el];
+    bool isPassMedium = (*medium_id_decisions)[el];
+    bool isPassTight  = (*tight_id_decisions)[el];
+    float mvaValue = (*mvaValues)[el];
+    float mvaCategory =  (*mvaCategories)[el];
 
+    localElectron.setisMVA_TightID( isPassTight );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+    localElectron.setisMVA_MediumID( isPassMedium );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+    localElectron.setisMVA_LooseID( isPassLoose );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+    localElectron.setMVA_value( mvaValue );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+    localElectron.setMVA_category( mvaCategory );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+    
     new( (*rootElectrons)[j] ) TRootElectron(localElectron);
     if(verbosity_>2) cout << "   ["<< setw(3) << j << "] " << localElectron << endl;
 }

--- a/src/ElectronAnalyzer.cc
+++ b/src/ElectronAnalyzer.cc
@@ -17,8 +17,9 @@ ElectronAnalyzer::ElectronAnalyzer(const edm::ParameterSet& myConfig, int verbos
 ElectronAnalyzer::~ElectronAnalyzer()
 {
 }
-
-void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken)
+// From CMSSW_8_1_X onwards
+//void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleLooseIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken)
+void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElectrons, const edm::EventSetup& iSetup, edm::EDGetTokenT<reco::BeamSpot> offlineBSToken, edm::EDGetTokenT<edm::View<pat::Electron>> electronToken, edm::EDGetTokenT<reco::VertexCollection> vtxToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleMediumIdMapToken, edm::EDGetTokenT<edm::ValueMap<bool> > eleTightIdMapToken, edm::EDGetTokenT<edm::ValueMap<float> > EleMVAValuesMapToken, edm::EDGetTokenT<edm::ValueMap<int> > EleMVACategoriesMapToken)
 {
   unsigned int nElectrons=0;
 
@@ -35,10 +36,10 @@ void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElect
   // Get the electron ID data from the event stream.
   // Note: this implies that the VID ID modules have been run upstream.
   // If you need more info, check with the EGM group.
-  edm::Handle<edm::ValueMap<bool> > loose_id_decisions;
+  //edm::Handle<edm::ValueMap<bool> > loose_id_decisions;// From CMSSW_8_1_X onwards
   edm::Handle<edm::ValueMap<bool> > medium_id_decisions;
   edm::Handle<edm::ValueMap<bool> > tight_id_decisions; 
-  iEvent.getByToken(eleLooseIdMapToken,loose_id_decisions);
+  //iEvent.getByToken(eleLooseIdMapToken,loose_id_decisions);// From CMSSW_8_1_X onwards
   iEvent.getByToken(eleMediumIdMapToken,medium_id_decisions);
   iEvent.getByToken(eleTightIdMapToken,tight_id_decisions);
 
@@ -210,7 +211,7 @@ void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElect
 	  std::cout << eleIds[ii].first << " " << eleIds[ii].second << std::endl;
       }
     }
-    bool isPassLoose = (*loose_id_decisions)[el];
+    //bool isPassLoose = (*loose_id_decisions)[el];  // From CMSSW_8_1_X onwards
     bool isPassMedium = (*medium_id_decisions)[el];
     bool isPassTight  = (*tight_id_decisions)[el];
     float mvaValue = (*mvaValues)[el];
@@ -218,7 +219,7 @@ void ElectronAnalyzer::Process(const edm::Event& iEvent, TClonesArray* rootElect
 
     localElectron.setisMVA_TightID( isPassTight );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
     localElectron.setisMVA_MediumID( isPassMedium );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
-    localElectron.setisMVA_LooseID( isPassLoose );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
+    //localElectron.setisMVA_LooseID( isPassLoose ); // From CMSSW_8_1_X onwards
     localElectron.setMVA_value( mvaValue );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
     localElectron.setMVA_category( mvaCategory );// https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
     

--- a/src/TopTreeProducer.cc
+++ b/src/TopTreeProducer.cc
@@ -77,7 +77,7 @@ TopTreeProducer::TopTreeProducer(const edm::ParameterSet& iConfig)
     genParticlesToken_ = consumes<std::vector<reco::GenParticle> >(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("prunedGenParticles"));
     lheproductToken_  = consumes<LHEEventProduct>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("lheproduct"));
     offlineBSToken_ = consumes<reco::BeamSpot>(valuesForConsumeCommand.getParameter<edm::InputTag>("offlineBeamSpot"));
-    eleLooseIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleLooseIdMap"));
+    //eleLooseIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleLooseIdMap")); // From CMSSW_8_1_X onwards
     eleMediumIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleMediumIdMap"));
     eleTightIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleTightIdMap"));
     mvaValuesMapToken_ = consumes<edm::ValueMap<float> >(valuesForConsumeCommand.getParameter<edm::InputTag>("electronMVAvaluesMapNonTrig"));
@@ -727,7 +727,9 @@ void TopTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         for(unsigned int s=0; s<vElectronProducer.size(); s++)
         {
             ElectronAnalyzer* myElectronAnalyzer = new ElectronAnalyzer(myConfig_, verbosity);
-            myElectronAnalyzer->Process(iEvent, velectrons[s], iSetup, offlineBSToken_, velectronToken_[s], vtxToken_, eleLooseIdMapToken_, eleMediumIdMapToken_, eleTightIdMapToken_, mvaValuesMapToken_, mvaCategoriesMapToken_);
+            // From CMSSW_8_1_X onwards
+            //myElectronAnalyzer->Process(iEvent, velectrons[s], iSetup, offlineBSToken_, velectronToken_[s], vtxToken_, eleLooseIdMapToken_, eleMediumIdMapToken_, eleTightIdMapToken_, mvaValuesMapToken_, mvaCategoriesMapToken_);
+            myElectronAnalyzer->Process(iEvent, velectrons[s], iSetup, offlineBSToken_, velectronToken_[s], vtxToken_, eleMediumIdMapToken_, eleTightIdMapToken_, mvaValuesMapToken_, mvaCategoriesMapToken_);
             delete myElectronAnalyzer;
         }
     }

--- a/src/TopTreeProducer.cc
+++ b/src/TopTreeProducer.cc
@@ -36,7 +36,7 @@ TopTreeProducer::TopTreeProducer(const edm::ParameterSet& iConfig)
     }
     for(unsigned int s=0; s<vElectronProducer.size(); s++)
     {
-		  velectronToken_.push_back(consumes<pat::ElectronCollection>(edm::InputTag(vElectronProducer[s])));
+		  velectronToken_.push_back(consumes<edm::View<pat::Electron>>(edm::InputTag(vElectronProducer[s])));
     }
     for(unsigned int s=0; s<vPhotonProducer.size(); s++)
     {
@@ -73,10 +73,15 @@ TopTreeProducer::TopTreeProducer(const edm::ParameterSet& iConfig)
     fixedGridRhoFastjetCentralCaloToken_ = consumes<double>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("fixedGridRhoFastjetCentralCalo"));
     fixedGridRhoFastjetCentralChargedPileUpToken_ = consumes<double>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("fixedGridRhoFastjetCentralChargedPileUp"));
     fixedGridRhoFastjetCentralNeutralToken_ = consumes<double>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("fixedGridRhoFastjetCentralNeutral"));
-	genEventInfoProductToken_ = consumes<GenEventInfoProduct>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("genEventInfoProduct"));
+	  genEventInfoProductToken_ = consumes<GenEventInfoProduct>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("genEventInfoProduct"));
     genParticlesToken_ = consumes<std::vector<reco::GenParticle> >(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("prunedGenParticles"));
     lheproductToken_  = consumes<LHEEventProduct>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("lheproduct"));
     offlineBSToken_ = consumes<reco::BeamSpot>(valuesForConsumeCommand.getParameter<edm::InputTag>("offlineBeamSpot"));
+    eleLooseIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleLooseIdMap"));
+    eleMediumIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleMediumIdMap"));
+    eleTightIdMapToken_ = consumes<edm::ValueMap<bool> >(valuesForConsumeCommand.getParameter<edm::InputTag>("eleTightIdMap"));
+    mvaValuesMapToken_ = consumes<edm::ValueMap<float> >(valuesForConsumeCommand.getParameter<edm::InputTag>("electronMVAvaluesMapNonTrig"));
+    mvaCategoriesMapToken_ = consumes<edm::ValueMap<int> >(valuesForConsumeCommand.getParameter<edm::InputTag>("electronMVACategoriesNonTrig"));
     
 }
 
@@ -722,10 +727,11 @@ void TopTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
         for(unsigned int s=0; s<vElectronProducer.size(); s++)
         {
             ElectronAnalyzer* myElectronAnalyzer = new ElectronAnalyzer(myConfig_, verbosity);
-            myElectronAnalyzer->Process(iEvent, velectrons[s], iSetup, offlineBSToken_, velectronToken_[s], vtxToken_);
+            myElectronAnalyzer->Process(iEvent, velectrons[s], iSetup, offlineBSToken_, velectronToken_[s], vtxToken_, eleLooseIdMapToken_, eleMediumIdMapToken_, eleTightIdMapToken_, mvaValuesMapToken_, mvaCategoriesMapToken_);
             delete myElectronAnalyzer;
         }
     }
+
 
     // Photons
     if(doPhoton)


### PR DESCRIPTION
I added the VID Electron procedure for mva electrons (https://twiki.cern.ch/twiki/bin/view/CMS/EgammaIDRecipesRun2#MVA_based_electron_Identificatio). From now on, the mva value for electrons will be available in the object information, together with the 6 different categories according to which it is defined. Also, the Medium and Tight decisions themselves are stored as reference.

Next to that, this pull also removes some unused variables from the electron object.