### PR TITLE
Update of HLT triggerResults, inlcuding HLT2 for the 80X reHLT samples

### DIFF
--- a/interface/HLTAnalyzer.h
+++ b/interface/HLTAnalyzer.h
@@ -26,7 +26,7 @@ class HLTAnalyzer
 	
 public:
 	
-	HLTAnalyzer(edm::EDGetTokenT<edm::TriggerResults> triggerToken1, edm::EDGetTokenT<edm::TriggerResults> triggerToken2,edm::EDGetTokenT<edm::TriggerResults> triggerToken3,edm::EDGetTokenT<edm::TriggerResults> triggerToken4, const edm::ParameterSet& myConfig, int verbosity);
+	HLTAnalyzer(edm::EDGetTokenT<edm::TriggerResults> triggerToken1, edm::EDGetTokenT<edm::TriggerResults> triggerToken2,edm::EDGetTokenT<edm::TriggerResults> triggerToken3, edm::EDGetTokenT<edm::TriggerResults> triggerToken4, edm::EDGetTokenT<edm::TriggerResults> triggerToken5, const edm::ParameterSet& myConfig, int verbosity);
 	
 	~HLTAnalyzer() {;}
 	
@@ -62,6 +62,7 @@ private:
 	edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken2nd_;	// Input Token for TriggerResults, 2nd choice
 	edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken3rd_;	// Input Token for TriggerResults, 3rd choice
 	edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken4th_;	// Input Token for TriggerResults, 4th choice
+	edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken5th_;	// Input Token for TriggerResults, 4th choice
 
 	edm::TriggerNames triggerNames_;			// TriggerNames class
 

--- a/interface/TopTreeProducer.h
+++ b/interface/TopTreeProducer.h
@@ -163,6 +163,7 @@ private:
     edm::EDGetTokenT<edm::TriggerResults> triggerToken2_;
     edm::EDGetTokenT<edm::TriggerResults> triggerToken3_;
     edm::EDGetTokenT<edm::TriggerResults> triggerToken4_;
+    edm::EDGetTokenT<edm::TriggerResults> triggerToken5_;
     edm::EDGetTokenT<edm::TriggerResults> metfilterToken_;
     edm::EDGetTokenT<HcalNoiseSummary> hcalNoiseSummaryToken_;
     edm::EDGetTokenT<std::vector< PileupSummaryInfo > > pileUpProducerToken_;

--- a/prod/TOPTREE_fromminiAOD.py
+++ b/prod/TOPTREE_fromminiAOD.py
@@ -15,7 +15,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 
 # good global tags can be found here. Beware that the default is MC which has to be updated for data!
 # https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions
-process.GlobalTag.globaltag = cms.string('76X_mcRun2_asymptotic_v12')
+process.GlobalTag.globaltag = cms.string('80X_mcRun2_asymptotic_2016_miniAODv2_v1')
 
 
 #
@@ -38,7 +38,7 @@ for idmod in my_id_modules:
 
 
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(1000)
+  input = cms.untracked.int32(-1)
 )
 
 process.options = cms.untracked.PSet(
@@ -48,7 +48,7 @@ process.options = cms.untracked.PSet(
 #Default Test sample
 #process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//store/mc/RunIISpring15DR74/TTJets_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v2/00000/18E6854B-1809-E511-A405-0025905B8590.root'))
 #process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_6_0/RelValTTbarLepton_13/MINIAODSIM/76X_mcRun2_asymptotic_v11-v1/00000/4A44647C-A77F-E511-A26B-002618943960.root'))
-process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring('root://xrootd-cms.infn.it///store/mc/RunIIFall15MiniAODv1/QCD_Pt-15to20_MuEnrichedPt5_TuneCUETP8M1_13TeV_pythia8/MINIAODSIM/PU25nsData2015v1_76X_mcRun2_asymptotic_v12-v1/00000/04C4FE54-95A8-E511-AD4D-0CC47A4D7686.root'))
+process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring('root://xrootd-cms.infn.it///store/mc/RunIISpring16MiniAODv2/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/PUSpring16RAWAODSIM_reHLT_80X_mcRun2_asymptotic_v14_ext3-v1/00000/0064B539-803A-E611-BDEA-002590D0B060.root'))
 
 #process.source = cms.Source("PoolSource",fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//store/mc/RunIISpring15DR74/TTJets_DiLept_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v2/20000/5E2A0DB9-E52F-E511-A294-782BCB407B74.root'))
 
@@ -151,13 +151,6 @@ process.analysis = cms.EDAnalyzer("TopTreeProducer",
     jetMC_ptMin = cms.double(15.0), #checking effect on filesize by tightening cuts here 5.0 -> 15.0
   ),
   
-  producersNames = cms.PSet(
-    hltProducer1st = cms.InputTag("TriggerResults","","HLT"),
-    hltProducer2nd = cms.InputTag("TriggerResults","","RECO"),
-    hltProducer3rd = cms.InputTag("TriggerResults","","MINIAOD"),
-    hltProducer4th = cms.InputTag("TriggerResults","","PAT"),
-    pileUpProducer = cms.InputTag("addPileupInfo","","HLT"),
-  ),
   
   #new for CMSSW76X and higher: all classes that are read from the event need to be registered in the constructor!
   #supposedly this is necessary in the case that the code is run on machines that use multi-threading.
@@ -187,9 +180,10 @@ process.analysis = cms.EDAnalyzer("TopTreeProducer",
     primaryVertexProducer = cms.untracked.InputTag("offlineSlimmedPrimaryVertices"),
     offlineBeamSpot = cms.InputTag("offlineBeamSpot"),
     hltProducer1st = cms.InputTag("TriggerResults","","HLT"),
-    hltProducer2nd = cms.InputTag("TriggerResults","","RECO"),
-    hltProducer3rd = cms.InputTag("TriggerResults","","MINIAOD"),
-    hltProducer4th = cms.InputTag("TriggerResults","","PAT"),
+    hltProducer2nd = cms.InputTag("TriggerResults","","HLT2"),
+    hltProducer3rd = cms.InputTag("TriggerResults","","RECO"),
+    hltProducer4th = cms.InputTag("TriggerResults","","MINIAOD"),
+    hltProducer5th = cms.InputTag("TriggerResults","","PAT"),
     electronMVAvaluesMapNonTrig = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Values"), #https://twiki.cern.ch/twiki/bin/view/CMS/MultivariateElectronIdentificationRun2
     electronMVACategoriesNonTrig = cms.InputTag("electronMVAValueMapProducer:ElectronMVAEstimatorRun2Spring15NonTrig25nsV1Categories"),
     #eleLooseIdMap = cms.InputTag("egmGsfElectronIDs:mvaEleID-Spring15-25ns-nonTrig-V1-wpLoose"), #Will only be available from CMSSW_8_1_X

--- a/src/HLTAnalyzer.cc
+++ b/src/HLTAnalyzer.cc
@@ -19,7 +19,7 @@ int getIndexForRun ( const edm::Event& iEvent, vector<TopTree::TRootHLTInfo> inf
 
 }
 
-HLTAnalyzer::HLTAnalyzer(edm::EDGetTokenT<edm::TriggerResults> triggerToken1, edm::EDGetTokenT<edm::TriggerResults> triggerToken2, edm::EDGetTokenT<edm::TriggerResults> triggerToken3, edm::EDGetTokenT<edm::TriggerResults> triggerToken4, const edm::ParameterSet& myConfig, int verbosity) :
+HLTAnalyzer::HLTAnalyzer(edm::EDGetTokenT<edm::TriggerResults> triggerToken1, edm::EDGetTokenT<edm::TriggerResults> triggerToken2,edm::EDGetTokenT<edm::TriggerResults> triggerToken3, edm::EDGetTokenT<edm::TriggerResults> triggerToken4, edm::EDGetTokenT<edm::TriggerResults> triggerToken5, const edm::ParameterSet& myConfig, int verbosity) :
 		verbosity_(verbosity)
   		,triggerNames_()
 		,doHLT_(myConfig.getUntrackedParameter<bool>("doHLT",false))
@@ -36,6 +36,7 @@ HLTAnalyzer::HLTAnalyzer(edm::EDGetTokenT<edm::TriggerResults> triggerToken1, ed
 		triggerResultsToken2nd_=triggerToken2;
 		triggerResultsToken3rd_=triggerToken3;
 		triggerResultsToken4th_=triggerToken4;
+		triggerResultsToken5th_=triggerToken5;
 		}
 
 void HLTAnalyzer::process(const edm::Event& iEvent, TRootEvent* rootEvent, edm::ParameterSet valuesForConsumeCommand)
@@ -52,11 +53,12 @@ void HLTAnalyzer::process(const edm::Event& iEvent, TRootEvent* rootEvent, edm::
 
 	  if ( index == -1 || index < (int)hltInfos_.size()-1 ) {// no info for this run yet -> create a new entry
 
-	    edm::Handle<edm::TriggerResults> trigResults, trigResults1st, trigResults2nd, trigResults3rd, trigResults4th;
+	    edm::Handle<edm::TriggerResults> trigResults, trigResults1st, trigResults2nd, trigResults3rd, trigResults4th, trigResults5th;
 	    try {iEvent.getByToken(triggerResultsToken1st_,trigResults1st);} catch (...) {;}
 	    try {iEvent.getByToken(triggerResultsToken2nd_,trigResults2nd);} catch (...) {;}
 	    try {iEvent.getByToken(triggerResultsToken3rd_,trigResults3rd);} catch (...) {;}
 	    try {iEvent.getByToken(triggerResultsToken4th_,trigResults4th);} catch (...) {;}
+	    try {iEvent.getByToken(triggerResultsToken5th_,trigResults5th);} catch (...) {;}
 	    if(trigResults1st.isValid())
 	      {
 				trigResults = trigResults1st;
@@ -79,7 +81,13 @@ void HLTAnalyzer::process(const edm::Event& iEvent, TRootEvent* rootEvent, edm::
 	    {
 	      trigResults = trigResults4th;
 	      triggerResultsToken_ = triggerResultsToken4th_;
-		  triggerResultsTag_ = valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer4th");
+		    triggerResultsTag_ = valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer4th");
+			}
+	    else if(trigResults5th.isValid())
+	    {
+	      trigResults = trigResults5th;
+	      triggerResultsToken_ = triggerResultsToken5th_;
+		    triggerResultsTag_ = valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer5th");
 			}
 
 	    triggerNames_=iEvent.triggerNames(*trigResults);

--- a/src/TopTreeProducer.cc
+++ b/src/TopTreeProducer.cc
@@ -13,13 +13,11 @@ using namespace edm;
 TopTreeProducer::TopTreeProducer(const edm::ParameterSet& iConfig)
 {
     myConfig_ = iConfig.getParameter<ParameterSet>("myConfig");
-    producersNames_ = iConfig.getParameter<ParameterSet>("producersNames");
     valuesForConsumeCommand = iConfig.getParameter<ParameterSet>("producerNamesBookkeepingThreads");
     
     // new for CMSSW76X and higher: all classes that are read from the event need to be registered in the constructor!
     // supposedly this is necessary in the case that the code is run on machines that use multi-threading.
     // It also allows the CMSSW compiler to optimise/speed up the code (or so the documentation says), by accessing collections that are used a lot or rarely with the consumesOften() and mayConsume() fuctions but consumes() will always work.
-    // in the TopTreeProducer .py file these are stored in either the producerNamesBookkeepingThreads parameter set or the producersNames parameter set (which contains vstrings used by the various analysers, so please add new objects there if you need them.
     
 	  vector<string> defaultVec;
     vMuonProducer = valuesForConsumeCommand.getUntrackedParameter<vector<string> >("vmuonProducer",defaultVec);
@@ -64,6 +62,7 @@ TopTreeProducer::TopTreeProducer(const edm::ParameterSet& iConfig)
     triggerToken2_ = consumes<edm::TriggerResults>(valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer2nd"));
     triggerToken3_ = consumes<edm::TriggerResults>(valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer3rd"));
     triggerToken4_ = consumes<edm::TriggerResults>(valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer4th"));
+    triggerToken5_ = consumes<edm::TriggerResults>(valuesForConsumeCommand.getParameter<edm::InputTag>("hltProducer5th"));
     pileUpProducerToken_ = consumes<std::vector< PileupSummaryInfo > >(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("pileUpProducer"));
     metfilterToken_ = consumes<edm::TriggerResults>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("metfilterProducer"));
 //    hcalNoiseSummaryToken_ = consumes<HcalNoiseSummary>(valuesForConsumeCommand.getUntrackedParameter<edm::InputTag>("summaryHBHENoise"));
@@ -184,7 +183,7 @@ void TopTreeProducer::beginJob()
     if(doHLT)
     {
         if(verbosity>0) cout << "HLT info will be added to rootuple" << endl;
-        hltAnalyzer_ = new HLTAnalyzer(triggerToken1_, triggerToken2_, triggerToken3_, triggerToken4_, myConfig_, verbosity);
+        hltAnalyzer_ = new HLTAnalyzer(triggerToken1_, triggerToken2_, triggerToken3_, triggerToken4_, triggerToken5_, myConfig_, verbosity);
     }
 
 
@@ -493,91 +492,6 @@ void TopTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     }
 
 
-    // we need to store some triggerFilter info to be able to emulate triggers on older data
-//    if (doHLT)
-//    {
-//        if (verbosity > 1) cout << "should do HLT now..." << endl;
-//
-//        // get Trigger summary from Event
-//        edm::Handle<trigger::TriggerEvent> summary, summary1st, summary2nd, summary3rd, summary4th;
-//        edm::InputTag summaryTag1st_("hltTriggerSummaryAOD","",(producersNames_.getParameter < edm::InputTag > ("hltProducer1st")).process());
-//        edm::InputTag summaryTag2nd_("hltTriggerSummaryAOD","",(producersNames_.getParameter < edm::InputTag > ("hltProducer2nd")).process());
-//        edm::InputTag summaryTag3rd_("hltTriggerSummaryAOD","",(producersNames_.getParameter < edm::InputTag > ("hltProducer3rd")).process());
-//        edm::InputTag summaryTag4th_("hltTriggerSummaryAOD","",(producersNames_.getParameter < edm::InputTag > ("hltProducer4th")).process());
-//
-//        try
-//        {
-//            iEvent.getByLabel(summaryTag1st_,summary1st);
-//        }
-//        catch (...)
-//        {
-//            ;
-//        }
-//        try
-//        {
-//            iEvent.getByLabel(summaryTag2nd_,summary2nd);
-//        }
-//        catch (...)
-//        {
-//            ;
-//        }
-//        try
-//        {
-//            iEvent.getByLabel(summaryTag3rd_,summary3rd);
-//        }
-//        catch (...)
-//        {
-//            ;
-//        }
-//        try
-//        {
-//            iEvent.getByLabel(summaryTag4th_,summary4th);
-//        }
-//        catch (...)
-//        {
-//            ;
-//        }
-//
-//        //cout << summaryTag1st_ << " " << summaryTag2nd_  << " " << summaryTag3rd_  << " " << summaryTag4th_ << endl;
-//        //cout << summaryTag1st_.process() << " " << summaryTag2nd_.process()<< " " << summaryTag3rd_.process()<< " " << summaryTag4th_.process() << endl;
-//        //cout << summary1st.isValid() << " " << summary2nd.isValid() << " " << summary3rd.isValid() << " " << summary4th.isValid()<< endl;
-//
-//        if (summary1st.isValid())
-//            summary = summary1st;
-//        else if (summary2nd.isValid())
-//            summary = summary2nd;
-//        else if (summary3rd.isValid())
-//            summary = summary3rd;
-//        else if (summary4th.isValid())
-//            summary = summary4th;
-//        else
-//            cout << "TopTreeProducer::Analyze ERROR: Could not store info for trigger emulation: provided HLTproducerNames are null" << endl;
-//
-//        //cout << "summary " << summary << endl;
-//
-//        if (summary.isValid())
-//        {
-//            for (unsigned int i=0; i<summary->sizeFilters(); i++)
-//            {
-//                if (verbosity > 1) cout << i << " -> " << summary->filterTag(i).label() << endl;
-//
-//                // get all trigger objects corresponding to this module.
-//                // loop through them and see how many objects match the selection
-//                const trigger::Keys& KEYS (summary->filterKeys(i));
-//                const int n1(KEYS.size());
-//
-//                for (int j=0; j!=n1; ++j)
-//                {
-//                    const trigger::TriggerObject& triggerObject( summary-> getObjects().at(KEYS[j]) );
-//                    //cout << "j: " << j << " -> id " << triggerObject.id() << endl;
-//                    //cout << "j: " << j << " -> pt " << triggerObject.pt() << endl;
-//                    //cout << "j: " << j << " -> eta " << triggerObject.eta() << endl;
-//                    //cout << "j: " << j << " -> phi " << triggerObject.phi() << endl;
-//                    rootEvent->AddTriggerObject(string(summary->filterTag(i).label()), triggerObject.id(),triggerObject.pt(),triggerObject.eta(),triggerObject.phi());
-//                }
-//            }
-//        }
-//    }
 
     //fastjet density rho
     //commenting out this rho for 7_0_X as it seems to be missing from miniAOD
@@ -633,7 +547,7 @@ void TopTreeProducer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     {
         if(verbosity>1) cout << endl << "Analysing MC info..." << endl;
         MCAnalyzer* myMCAnalyzer = new MCAnalyzer(myConfig_,verbosity);
-        if (drawMCTree) myMCAnalyzer->DrawMCTree(iEvent, iSetup, myConfig_, producersNames_);
+        if (drawMCTree) myMCAnalyzer->DrawMCTree(iEvent, iSetup, myConfig_, valuesForConsumeCommand);
         if (doPDFInfo ) myMCAnalyzer->PDFInfo(iEvent, rootEvent, genEventInfoProductToken_);
         myMCAnalyzer->ProcessMCParticle(iEvent, mcParticles, genParticlesToken_);
         delete myMCAnalyzer;


### PR DESCRIPTION
For the reHLT samples, you can not use the regular HLT triggerResults. I've adapted the HLTAnalyzer, adding an extra triggerResults for this reHLT campaign. I've tested it locally and the triggers are indeed included now for reHLT samples.